### PR TITLE
Cascade parent parameter and method data

### DIFF
--- a/src/main/java/org/parchmentmc/compass/tasks/GenerateExport.java
+++ b/src/main/java/org/parchmentmc/compass/tasks/GenerateExport.java
@@ -90,7 +90,7 @@ public abstract class GenerateExport extends DefaultTask {
     @Nullable
     @Internal
     protected SourceMetadata getSourceMetadata() throws IOException {
-        if (getUseBlackstone().get() == Boolean.TRUE) {
+        if (getUseBlackstone().get()) {
             final BlackstoneDownloader blackstoneDownloader = getProject().getPlugins()
                     .getPlugin(CompassPlugin.class).getBlackstoneDownloader();
             return blackstoneDownloader.retrieveMetadata();

--- a/src/main/java/org/parchmentmc/compass/tasks/GenerateExport.java
+++ b/src/main/java/org/parchmentmc/compass/tasks/GenerateExport.java
@@ -8,18 +8,29 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.Nullable;
 import org.parchmentmc.compass.CompassPlugin;
 import org.parchmentmc.compass.providers.IntermediateProvider;
 import org.parchmentmc.compass.storage.io.MappingIOFormat;
 import org.parchmentmc.compass.storage.io.SingleFileDataIO;
 import org.parchmentmc.compass.util.MappingUtil;
+import org.parchmentmc.compass.util.download.BlackstoneDownloader;
 import org.parchmentmc.feather.io.moshi.MDCMoshiAdapter;
 import org.parchmentmc.feather.io.moshi.SimpleVersionAdapter;
+import org.parchmentmc.feather.mapping.MappingDataBuilder;
 import org.parchmentmc.feather.mapping.MappingDataContainer;
+import org.parchmentmc.feather.metadata.ClassMetadata;
+import org.parchmentmc.feather.metadata.MethodMetadata;
+import org.parchmentmc.feather.metadata.MethodReference;
+import org.parchmentmc.feather.metadata.SourceMetadata;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 public abstract class GenerateExport extends DefaultTask {
     private static final SingleFileDataIO IO = new SingleFileDataIO(new Moshi.Builder()
@@ -28,6 +39,7 @@ public abstract class GenerateExport extends DefaultTask {
 
     public GenerateExport() {
         getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("export.json")));
+        getUseBlackstone().convention(Boolean.FALSE);
 
         onlyIf(_t -> getInput().get().getAsFile().exists());
     }
@@ -51,7 +63,13 @@ public abstract class GenerateExport extends DefaultTask {
     }
 
     protected MappingDataContainer modifyData(MappingDataContainer container) throws IOException {
-        return container;
+        final MappingDataBuilder builder = MappingDataBuilder.copyOf(container);
+        final SourceMetadata metadata = getSourceMetadata();
+        final Map<String, ClassMetadata> classMetadataMap = MappingUtil.buildClassMetadataMap(metadata);
+
+        builder.getClasses().forEach(clsData -> cascadeParentMethods(builder, classMetadataMap, clsData, classMetadataMap.get(clsData.getName())));
+
+        return builder;
     }
 
     @InputDirectory
@@ -65,4 +83,76 @@ public abstract class GenerateExport extends DefaultTask {
 
     @OutputFile
     public abstract RegularFileProperty getOutput();
+
+    @Input
+    public abstract Property<Boolean> getUseBlackstone();
+
+    @Nullable
+    @Internal
+    protected SourceMetadata getSourceMetadata() throws IOException {
+        if (getUseBlackstone().get() == Boolean.TRUE) {
+            final BlackstoneDownloader blackstoneDownloader = getProject().getPlugins()
+                    .getPlugin(CompassPlugin.class).getBlackstoneDownloader();
+            return blackstoneDownloader.retrieveMetadata();
+        } else {
+            return null;
+        }
+    }
+
+    protected static void cascadeParentMethods(MappingDataBuilder builder, Map<String, ClassMetadata> classMetadataMap, MappingDataBuilder.MutableClassData clsData, ClassMetadata clsMeta) {
+        if (clsMeta == null)
+            return;
+        // We need to cascade data using the class metadata methods because methods with no mapped data will not be present in ClassData#getMethods()
+        clsMeta.getMethods().forEach(methodMeta -> {
+            String name = methodMeta.getName().getMojangName().orElse(null);
+            String desc = methodMeta.getDescriptor().getMojangName().orElse(null);
+            if (name == null || desc == null)
+                return;
+            GenerateExport.cascadeParentMethod(builder, classMetadataMap, methodMeta, () -> clsData.getOrCreateMethod(name, desc));
+        });
+    }
+
+    /**
+     * This code cascades parameters and javadocs from parent methods,
+     * stopping at the first one that has something populated.
+     */
+    private static void cascadeParentMethod(MappingDataBuilder builder, Map<String, ClassMetadata> classMetadataMap, MethodMetadata methodMeta,
+            Supplier<MappingDataBuilder.MutableMethodData> methodDataSupplier) {
+        MethodMetadata parentMethodMeta = methodMeta;
+        MappingDataBuilder.MutableMethodData parentMethodData = null;
+
+        while (parentMethodData == null && parentMethodMeta != null && parentMethodMeta.getParent().isPresent()) {
+            MethodReference parent = parentMethodMeta.getParent().get();
+            // Get the current method metadata so we can get the next parent
+            parentMethodMeta = classMetadataMap.get(parent.getOwner().getMojangName().orElse("")).getMethods().stream()
+                    .filter(m -> m.getName().getMojangName().equals(parent.getName().getMojangName())
+                            && m.getDescriptor().getMojangName().equals(parent.getDescriptor().getMojangName()))
+                    .findFirst().orElse(null);
+            // Query the actual mapping data to see if the parent method has any javadocs or parameters
+            parentMethodData = Optional.ofNullable(builder.getClass(parent.getOwner().getMojangName().orElse("")))
+                    .map(c -> c.getMethod(parent.getName().getMojangName().orElse(""), parent.getDescriptor().getMojangName().orElse("")))
+                    .filter(m -> !m.getJavadoc().isEmpty() || m.getParameters().stream().anyMatch(p -> p.getJavadoc() != null || p.getName() != null))
+                    .orElse(null);
+        }
+
+        // This code cascades the data only if there is as valid parent method with mapping data
+        if (parentMethodData != null) {
+            MappingDataBuilder.MutableMethodData methodData = methodDataSupplier.get();
+            if (methodData.getJavadoc().isEmpty())
+                methodData.addJavadoc(parentMethodData.getJavadoc());
+
+            parentMethodData.getParameters().forEach(parentParam -> {
+                byte idx = parentParam.getIndex();
+                MappingDataBuilder.MutableParameterData thisParam = methodData.getParameter(idx);
+
+                // Cascade the parameter name only if the current parameter doesn't have it
+                if ((thisParam == null || thisParam.getName() == null) && parentParam.getName() != null)
+                    methodData.getOrCreateParameter(idx).setName(parentParam.getName());
+
+                // Cascade the parameter javadocs only if the current parameter doesn't have it
+                if ((thisParam == null || thisParam.getJavadoc() == null) && parentParam.getJavadoc() != null)
+                    methodData.getOrCreateParameter(idx).setJavadoc(parentParam.getJavadoc());
+            });
+        }
+    }
 }


### PR DESCRIPTION
This PR modifies how `GenerateExport` and `GenerateSanitizedExport` function to support cascading data from parent methods that are overriden in subclasses.
* If `useBlackstone` is `true`, then each class will have all its methods checked for parent methods. If a parent method exists and has mapping data, it will be cascaded to the subclass method if the subclass method does not override the mapping data with its own. 
* With this PR, one could theoretically map only a single parameter or only javadocs that changes in a subclass method from its parent class, and the export do the rest of the work filling in from the parent.
* The `useBlackstone` Gradle property has been moved up to `GenerateExport` to support this new cascading in both normal and sanitized exports