### PR TITLE
Add support for ParchmentJAM for migrating mapping data

### DIFF
--- a/src/main/java/org/parchmentmc/compass/CompassExtension.java
+++ b/src/main/java/org/parchmentmc/compass/CompassExtension.java
@@ -1,18 +1,24 @@
 package org.parchmentmc.compass;
 
+import org.gradle.api.Action;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.parchmentmc.compass.storage.io.MappingIOFormat;
 
 public abstract class CompassExtension {
-    public CompassExtension(final ProjectLayout layout) {
+    private final MigrationConfiguration migration;
+
+    public CompassExtension(final ProjectLayout layout, final ObjectFactory objects) {
         getLauncherManifestURL().convention("https://piston-meta.mojang.com/mc/game/version_manifest_v2.json");
         getProductionData().convention(layout.getProjectDirectory().dir("data"));
         getProductionDataFormat().convention(MappingIOFormat.ENIGMA_EXPLODED);
         getStagingData().convention(layout.getProjectDirectory().dir("staging"));
         getStagingDataFormat().convention(MappingIOFormat.ENIGMA_EXPLODED);
         getInputs().convention(layout.getProjectDirectory().dir("input"));
+
+        this.migration = objects.newInstance(MigrationConfiguration.class, this);
     }
 
     public abstract Property<String> getLauncherManifestURL();
@@ -28,4 +34,12 @@ public abstract class CompassExtension {
     public abstract Property<MappingIOFormat> getStagingDataFormat();
 
     public abstract DirectoryProperty getInputs();
+
+    public MigrationConfiguration getMigration() {
+        return this.migration;
+    }
+
+    public void migration(Action<? super MigrationConfiguration> configure) {
+        configure.execute(this.migration);
+    }
 }

--- a/src/main/java/org/parchmentmc/compass/CompassExtension.java
+++ b/src/main/java/org/parchmentmc/compass/CompassExtension.java
@@ -35,10 +35,21 @@ public abstract class CompassExtension {
 
     public abstract DirectoryProperty getInputs();
 
+    /**
+     * The configuration for the data migration system.
+     *
+     * @return The configuration for the data migration system.
+     * @see #migration(Action)
+     */
     public MigrationConfiguration getMigration() {
         return this.migration;
     }
 
+    /**
+     * Configures the data migration system.
+     *
+     * @param configure The action or closure to configure the data migration system with.
+     */
     public void migration(Action<? super MigrationConfiguration> configure) {
         configure.execute(this.migration);
     }

--- a/src/main/java/org/parchmentmc/compass/CompassPlugin.java
+++ b/src/main/java/org/parchmentmc/compass/CompassPlugin.java
@@ -14,7 +14,12 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.parchmentmc.compass.providers.DelegatingProvider;
 import org.parchmentmc.compass.providers.IntermediateProvider;
 import org.parchmentmc.compass.providers.mcpconfig.SRGProvider;
-import org.parchmentmc.compass.tasks.*;
+import org.parchmentmc.compass.tasks.CopyData;
+import org.parchmentmc.compass.tasks.CreateStagingData;
+import org.parchmentmc.compass.tasks.DisplayMinecraftVersions;
+import org.parchmentmc.compass.tasks.GenerateExport;
+import org.parchmentmc.compass.tasks.SanitizeData;
+import org.parchmentmc.compass.tasks.ValidateData;
 import org.parchmentmc.compass.util.MappingUtil;
 import org.parchmentmc.compass.util.download.BlackstoneDownloader;
 import org.parchmentmc.compass.util.download.ManifestsDownloader;
@@ -119,6 +124,8 @@ public class CompassPlugin implements Plugin<Project> {
                 t.getInputFormat().set(extension.getStagingDataFormat());
             });
         });
+
+        extension.getMigration().setup(project, this);
     }
 
     private void createValidationTask(CompassExtension extension, TaskContainer tasks) {

--- a/src/main/java/org/parchmentmc/compass/MigrationConfiguration.java
+++ b/src/main/java/org/parchmentmc/compass/MigrationConfiguration.java
@@ -58,19 +58,18 @@ public abstract class MigrationConfiguration {
                 .finalizeValueOnRead();
         getExcludedVersions()
                 .convention(providers.gradleProperty("migration-excludedVersions")
-                        .map(COMMA_SPLITTER::split))
+                        .map(COMMA_SPLITTER::split)
+                        // By default, exclude the April Fools versions
+                        // Note that Minecraft 2.0, despite being an April Fools version, was never published to the launcher
+                        .orElse(ImmutableSet.of(
+                                "15w14a",
+                                "1.RV-Pre1",
+                                "3D Shareware v1.34",
+                                "20w14infinite",
+                                "22w13oneblockatatime",
+                                "23w13a_or_b"
+                        )))
                 .finalizeValueOnRead();
-
-        // By default, exclude the April Fools versions
-        // Note that Minecraft 2.0, despite being an April Fools version, was never published to the launcher
-        getExcludedVersions().convention(ImmutableSet.of(
-                "15w14a",
-                "1.RV-Pre1",
-                "3D Shareware v1.34",
-                "20w14infinite",
-                "22w13oneblockatatime",
-                "23w13a_or_b"
-        ));
     }
 
     public abstract Property<String> getTargetVersion();

--- a/src/main/java/org/parchmentmc/compass/MigrationConfiguration.java
+++ b/src/main/java/org/parchmentmc/compass/MigrationConfiguration.java
@@ -1,0 +1,284 @@
+package org.parchmentmc.compass;
+
+import com.google.common.collect.ImmutableSet;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.parchmentmc.compass.storage.io.MappingIOFormat;
+import org.parchmentmc.compass.tasks.CopyData;
+import org.parchmentmc.compass.tasks.DownloadVersionManifest;
+import org.parchmentmc.compass.tasks.JAMMERExec;
+import org.parchmentmc.compass.tasks.VersionDownload;
+import org.parchmentmc.compass.util.JSONUtil;
+import org.parchmentmc.compass.util.download.BlackstoneDownloader;
+import org.parchmentmc.feather.manifests.LauncherManifest;
+import org.parchmentmc.feather.manifests.LauncherManifest.VersionData;
+import org.parchmentmc.feather.manifests.VersionManifest;
+
+import javax.inject.Inject;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class MigrationConfiguration {
+    private static final Logger LOGGER = Logging.getLogger(MigrationConfiguration.class);
+    public static final String JAMMER_CONFIGURATION_NAME = "jammer";
+
+    private final CompassExtension extension;
+
+    @Inject
+    public MigrationConfiguration(final CompassExtension extension) {
+        this.extension = extension;
+
+        getTargetVersion().finalizeValueOnRead();
+        getExcludedVersions().finalizeValueOnRead();
+
+        // By default, exclude the April Fools versions
+        // Note that Minecraft 2.0, despite being an April Fools version, was never published to the launcher
+        getExcludedVersions().convention(ImmutableSet.of(
+                "15w14a",
+                "1.RV-Pre1",
+                "3D Shareware v1.34",
+                "20w14infinite",
+                "22w13oneblockatatime",
+                "23w13a_or_b"
+        ));
+    }
+
+    public abstract Property<String> getTargetVersion();
+
+    public abstract SetProperty<String> getExcludedVersions();
+
+    // Below here lies implementation details
+
+    void setup(final Project project, final CompassPlugin plugin) {
+        project.getConfigurations().create(JAMMER_CONFIGURATION_NAME, c -> {
+            c.setCanBeResolved(true);
+            c.setCanBeConsumed(false);
+            c.setDescription("Configuration for the JAMMER (JarAwareMapping) data migration tool.");
+        });
+
+        project.afterEvaluate(p -> {
+            final @Nullable String targetVersion = extension.getMigration().getTargetVersion().getOrNull();
+            if (targetVersion != null) {
+                final Set<String> excludedVersions = extension.getMigration().getExcludedVersions().get();
+                setupMigration(project, plugin, extension, targetVersion, excludedVersions);
+            }
+        });
+    }
+
+    private static void setupMigration(final Project project, final CompassPlugin plugin, final CompassExtension extension,
+                                       final String targetVersion, final Collection<String> excludedVersions) {
+        //
+        // Determine the versions to be passed to JAMMER
+        //
+
+        final String currentVersion = extension.getVersion().get();
+        final LauncherManifest launcherManifest = plugin.getManifestsDownloader().getLauncherManifest().get();
+
+        final List<String> versionIds = launcherManifest.getVersions().stream().map(VersionData::getId).collect(Collectors.toList());
+
+        // Just in case, verify the configured excluded versions do exist, and warn if not
+        for (String excludedVersion : excludedVersions) {
+            if (!versionIds.contains(excludedVersion)) {
+                LOGGER.warn("Excluded version {} does not exist in launcher manifest", excludedVersion);
+            }
+        }
+
+        final int targetVersionIndex = versionIds.indexOf(targetVersion);
+        if (targetVersionIndex == -1)
+            throw new InvalidUserDataException("Migration target version " + targetVersion + " does not exist in launcher manifest");
+        final int currentVersionIndex = versionIds.indexOf(currentVersion);
+        assert currentVersionIndex != -1;
+
+        if (targetVersionIndex == currentVersionIndex)
+            throw new InvalidUserDataException("Migration target version " + targetVersion + " is the same as the current version");
+
+        final int firstVersion = Math.min(targetVersionIndex, currentVersionIndex);
+        final int lastVersion = Math.max(targetVersionIndex, currentVersionIndex);
+
+        final List<VersionData> versions = new ArrayList<>(launcherManifest.getVersions().subList(firstVersion, lastVersion + 1));
+        if (firstVersion == targetVersionIndex) {
+            // The first version in the list is the target version, therefore we reverse the list so the last version in
+            // the list is the target version
+            Collections.reverse(versions);
+        }
+        versions.removeIf(ver -> excludedVersions.contains(ver.getId()));
+        final Deque<VersionData> versionsToProcess = new ArrayDeque<>(versions);
+
+        LOGGER.lifecycle("Setting up migration for the following versions in order: {}",
+                versionsToProcess.stream().map(VersionData::getId).collect(Collectors.joining(" -> ")));
+
+        // 
+        // Setup the tasks
+        //
+
+        // For task dependency inference to work, the return value of a file property getter (i.e. `Provider<RegularFile> getOutput()`)
+        // *MUST* be an instance of `Property`, even if it's only exposed to API as a `Provider`. It kinda makes sense --
+        // since the `Property` instance will be configured at creation by Gradle's magic to know it's connected to a task,
+        // which it probably can't do to an arbitrary `Provider`.
+
+        final TaskContainer tasks = project.getTasks();
+        project.getConfigurations().maybeCreate(JAMMER_CONFIGURATION_NAME);
+
+        final TaskProvider<CopyData> copyDataForMigration = tasks.register("copyDataForMigration", CopyData.class,
+                task -> {
+                    task.getInputDirectory().set(extension.getProductionData());
+                    task.getInputFormat().set(extension.getProductionDataFormat());
+                    task.getOutputFile().set(project.getLayout().getBuildDirectory().dir(task.getName()).map(d -> d.file("production.json")));
+                    task.getOutputFormat().set(MappingIOFormat.MDC_SINGLE);
+                });
+
+        TaskProvider<JAMMERExec> migrationTask;
+        Provider<RegularFile> identifiers = copyDataForMigration.flatMap(CopyData::getOutputFile);
+        VersionData previous = versionsToProcess.removeFirst();
+        VersionJammerData previousData = createVersionTasks(project, previous);
+        do {
+            final VersionData current = versionsToProcess.removeFirst();
+            final VersionJammerData currentData = createVersionTasks(project, current);
+
+            migrationTask = setupMigration(project,
+                    previous,
+                    previousData,
+                    identifiers,
+                    current,
+                    currentData);
+            identifiers = migrationTask.flatMap(JAMMERExec::getOutputMapping);
+
+            previous = current;
+        } while (!versionsToProcess.isEmpty());
+
+        // After processing, identifiers will contain the last output of the last migration task
+        final Provider<RegularFile> migratedData = identifiers;
+
+        final TaskProvider<CopyData> writeMigratedData = tasks.register("writeMigratedData", CopyData.class,
+                task -> {
+                    task.getInputFile().set(migratedData);
+                    task.getInputFormat().set(MappingIOFormat.MDC_SINGLE);
+                    task.getOutputDirectory().set(extension.getStagingData());
+                    task.getOutputFormat().set(extension.getStagingDataFormat());
+                });
+
+        project.getTasks().register("migrateData", Task.class, task -> {
+            task.setGroup("parchment");
+            task.setDescription("Migrates the mapping data from the current version to a target version.");
+            task.dependsOn(writeMigratedData);
+        });
+    }
+
+    private static TaskProvider<JAMMERExec> setupMigration(final Project project,
+                                                           final VersionData input,
+                                                           final VersionJammerData inputData,
+                                                           final Provider<RegularFile> inputIdentifiers,
+                                                           final VersionData output,
+                                                           final VersionJammerData outputData) {
+
+        return project.getTasks().register(name("migrate", input.getId(), "to", output.getId(), "mappings"),
+                JAMMERExec.class, task -> {
+
+                    task.classpath(project.getConfigurations().named(JAMMER_CONFIGURATION_NAME));
+
+                    task.getOutputDirectory()
+                            .set(project.getLayout().getBuildDirectory().dir("migrations").map(d -> d.dir(task.getName())));
+
+                    task.getExistingVersions().register(input.getId(), ver -> {
+                        ver.getJar().set(inputData.clientJar);
+                        ver.getMappings().set(inputData.clientMappings);
+                        ver.getMetadata().set(inputData.blackstone);
+                        ver.getIdentifiers().set(inputIdentifiers);
+                    });
+
+                    task.targetVersion(output.getId(), ver -> {
+                        ver.getJar().set(outputData.clientJar);
+                        ver.getMappings().set(outputData.clientMappings);
+                        ver.getMetadata().set(outputData.blackstone);
+                    });
+                });
+    }
+
+    private static VersionJammerData createVersionTasks(final Project project, final VersionData version) {
+        final TaskContainer tasks = project.getTasks();
+        final String versionId = version.getId();
+
+        // Version manifest
+        final TaskProvider<DownloadVersionManifest> downloadManifest = tasks.register(name("download", versionId, "manifest"),
+                DownloadVersionManifest.class, task -> task.getVersion().set(versionId));
+
+        final Provider<VersionManifest> versionManifest = downloadManifest.flatMap(DownloadVersionManifest::getVersionManifest)
+                .map(RegularFile::getAsFile)
+                .map(JSONUtil::tryParseVersionManifest);
+
+        // Client JAR
+        final TaskProvider<VersionDownload> downloadClientJar = tasks.register(name("download", versionId, "client", "jar"),
+                VersionDownload.class, task -> {
+                    task.getManifest().set(versionManifest);
+                    task.getDownloadKey().set("client");
+                });
+
+        // Client mappings
+        final TaskProvider<VersionDownload> downloadClientMappings = tasks.register(name("download", versionId, "client", "mappings"),
+                VersionDownload.class, task -> {
+                    task.getManifest().set(versionManifest);
+                    task.getDownloadKey().set("client_mappings");
+                    task.getFileName().set(versionId + "-client.txt");
+                });
+
+        // Blackstone
+        final Configuration blackstoneConfiguration = project.getConfigurations().detachedConfiguration(
+                project.getDependencies().create(String.format(Locale.ROOT, BlackstoneDownloader.DEFAULT_BLACKSTONE_ARTIFACT_DEPENDENCY, versionId))
+        );
+
+        final Provider<RegularFile> blackstone = project.getLayout().file(
+                blackstoneConfiguration.getElements().map(s -> s.iterator().next()).map(FileSystemLocation::getAsFile));
+
+        return new VersionJammerData(
+                downloadClientJar.flatMap(VersionDownload::getOutputFile),
+                downloadClientMappings.flatMap(VersionDownload::getOutputFile),
+                blackstone);
+    }
+
+    private static class VersionJammerData {
+        final Provider<RegularFile> clientJar;
+        final Provider<RegularFile> clientMappings;
+        final Provider<RegularFile> blackstone;
+
+        private VersionJammerData(Provider<RegularFile> clientJar,
+                                  Provider<RegularFile> clientMappings,
+                                  Provider<RegularFile> blackstone) {
+            this.clientJar = clientJar;
+            this.clientMappings = clientMappings;
+            this.blackstone = blackstone;
+        }
+    }
+
+    private static String name(String... names) {
+        if (names.length == 0) return "";
+        if (names.length == 1) return names[0];
+
+        return Stream.concat(Stream.of(names[0]), Arrays.stream(names).skip(1).map(MigrationConfiguration::capitalize)).collect(Collectors.joining());
+    }
+
+    private static String capitalize(String str) {
+        if (str.length() <= 1) return str;
+        return str.substring(0, 1).toUpperCase(Locale.ROOT) + str.substring(1);
+    }
+}

--- a/src/main/java/org/parchmentmc/compass/tasks/DownloadVersionManifest.java
+++ b/src/main/java/org/parchmentmc/compass/tasks/DownloadVersionManifest.java
@@ -1,0 +1,64 @@
+package org.parchmentmc.compass.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.parchmentmc.compass.CompassPlugin;
+import org.parchmentmc.feather.manifests.LauncherManifest;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.parchmentmc.compass.util.download.DownloadUtil.areNotChecksumsEqual;
+import static org.parchmentmc.compass.util.download.DownloadUtil.createAndExecuteAction;
+import static org.parchmentmc.compass.util.download.DownloadUtil.verifyChecksum;
+
+public abstract class DownloadVersionManifest extends DefaultTask {
+    @Input
+    public abstract Property<LauncherManifest> getLauncherManifest();
+
+    @Input
+    public abstract Property<String> getVersion();
+
+    @OutputFile
+    public abstract RegularFileProperty getVersionManifest();
+
+    @Inject
+    public DownloadVersionManifest(final ProjectLayout layout) {
+        final CompassPlugin plugin = getProject().getPlugins().getPlugin(CompassPlugin.class);
+
+        getLauncherManifest().convention(plugin.getManifestsDownloader().getLauncherManifest());
+
+        getVersionManifest().convention(layout.getBuildDirectory().dir("manifests")
+                .zip(getVersion(), (d, v) -> d.file(v + ".json")));
+    }
+
+    @TaskAction
+    public void execute() {
+        final String version = getVersion().get();
+        final LauncherManifest.VersionData versionData = getLauncherManifest().get().getVersions().stream()
+                .filter(str -> str.getId().equals(version))
+                .findFirst()
+                .orElseThrow(() -> new InvalidUserDataException("No version data found for " + version));
+
+        final File outputFile = getVersionManifest().get().getAsFile();
+
+        // Only download if our expected hash (from the launcher manifest) is different from our on-disk file
+        if (!outputFile.exists() || areNotChecksumsEqual(outputFile, versionData.getSHA1())) {
+            try {
+                createAndExecuteAction(this.getProject(), versionData.getUrl(), outputFile, "version manifest");
+                verifyChecksum(outputFile, versionData.getSHA1(), "version manifest");
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to download version manifest for " + version, e);
+            }
+            setDidWork(true);
+        }
+    }
+}

--- a/src/main/java/org/parchmentmc/compass/tasks/JAMMERExec.java
+++ b/src/main/java/org/parchmentmc/compass/tasks/JAMMERExec.java
@@ -1,0 +1,115 @@
+package org.parchmentmc.compass.tasks;
+
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class JAMMERExec extends JavaExec {
+    private final Provider<RegularFile> outputMapping;
+
+    @Nested
+    public abstract NamedDomainObjectContainer<IdentifiedVersion> getExistingVersions();
+
+    @Nested
+    public abstract Property<Version> getTargetVersion();
+
+    public Version targetVersion(String version) {
+        final Version ver = getObjects().newInstance(Version.class, version);
+        getTargetVersion().set(ver);
+        return ver;
+    }
+
+    public void targetVersion(String version, Action<? super Version> action) {
+        action.execute(targetVersion(version));
+    }
+
+    @Internal("Represented as part of outputMapping")
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @OutputFile
+    public Provider<RegularFile> getOutputMapping() {
+        return outputMapping;
+    }
+
+    @Inject
+    protected abstract ObjectFactory getObjects();
+
+    @Inject
+    public JAMMERExec(final ProjectLayout layout) {
+        // Always run the task
+        getOutputs().upToDateWhen(s -> false);
+
+        getMainClass().set("org.parchmentmc.jam.Main");
+
+        getOutputDirectory().convention(layout.getBuildDirectory().dir(getName()));
+        outputMapping = getObjects().fileProperty()
+                .convention(getOutputDirectory().file("output.json"));
+
+        getArgumentProviders().add(() -> Arrays.asList("--outputPath", getOutputDirectory().get().getAsFile().getAbsolutePath()));
+        getArgumentProviders().add(() -> {
+            List<String> arguments = new ArrayList<>();
+            getExistingVersions().forEach(ver -> arguments.addAll(Arrays.asList(
+                    "--existingNames", ver.getName(),
+                    "--existingJars", ver.getJar().get().getAsFile().getAbsolutePath(),
+                    "--existingMappings", ver.getMappings().get().getAsFile().getAbsolutePath(),
+                    "--existingMetadata", ver.getMetadata().get().getAsFile().getAbsolutePath(),
+                    "--existingIdentifiers", ver.getIdentifiers().get().getAsFile().getAbsolutePath()
+            )));
+            return arguments;
+        });
+        getArgumentProviders().add(() -> {
+            final Version targetVer = getTargetVersion().get();
+            return Arrays.asList(
+                    "--inputName", targetVer.getName(),
+                    "--inputJar", targetVer.getJar().get().getAsFile().getAbsolutePath(),
+                    "--inputMapping", targetVer.getMappings().get().getAsFile().getAbsolutePath(),
+                    "--inputMetadata", targetVer.getMetadata().get().getAsFile().getAbsolutePath()
+            );
+        });
+
+        doFirst(t -> {
+            if (getExistingVersions().size() <= 0)
+                throw new RuntimeException("There should be at least one existing version");
+        });
+    }
+
+    public interface Version extends Named {
+        @Override
+        @Input
+        @NotNull
+        String getName();
+
+        @InputFile
+        RegularFileProperty getJar();
+
+        @InputFile
+        RegularFileProperty getMappings();
+
+        @InputFile
+        RegularFileProperty getMetadata();
+    }
+
+    public interface IdentifiedVersion extends Version {
+        @InputFile
+        RegularFileProperty getIdentifiers();
+    }
+}


### PR DESCRIPTION
This PR implements integration with JAMMER/JarAwareMapping in Compass, through the Parchment-specific integration application https://github.com/ParchmentMC/ParchmentJAM, which will resolve #19.

### Testing this PR

Aside from configuring your Parchment repository to use this PR (preferrably, via `includeBuild` in the `pluginManagement` section of your `settings.gradle`[^includeBuild]), the following should be in the buildscript (either as part of other existing sections, or just copy-pasted at the very bottom):

```gradle
dependencies {
    // ParchmentJAM, JAMMER integration for migrating mapping data 
    jammer 'org.parchmentmc.jam:jam-parchment:0.1.0'
}

compass {
    migration {
        targetVersion = '1.19.4' // Assuming the current version is 1.20.1
    }
}
```

You can determine if the migration system has been configured properly if the console output shows the path of versions which will be taken during migration (`Setting up migration for the following versions in order: [...]`), and the `migrateData` task is visible under the `parchment` group.

### Some notes
- Yes, the target version can either be forwards or backwards of the current version.
- The final data is placed into the _staging_ data environment (`staging` folder), and not directly into the production data environment (`data` folder). This allows the user a chance to determine changes between the new data and the old data, and make manual modifications if necessary.

  Once the user is satisfied with the changes (or this is run in automation), the `promoteStagingToProduction` task can be executed to move the data from staging to production.
- The migration can also be configured with the `migration-targetVersion` and `migration-excludedVersion` (comma-separated values) [project properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties).

---

Remaining work:

- [x] Add more documentation to the migration configuration extension, and other classes.
- [x] Allow configuring the migration options via project properties or environment variables.

[^includeBuild]: For example, assuming that this PR is cloned to a directory `Compass` adjacent to your mappings repository, add the line `includeBuild('../Compass')` under the `pluginManagement` block of your mapping repository's `settings.gradle` file. Upon invoking Gradle (or refreshing your IDE's Gradle integration), you should see mentions of the Compass repository in the console output.